### PR TITLE
Add support for Toasts

### DIFF
--- a/QuickAndroid/Toast.qml
+++ b/QuickAndroid/Toast.qml
@@ -1,0 +1,25 @@
+import QtQuick 2.0
+import QuickAndroid 0.1
+
+Item {
+    /// The message that will be displayed when show() is called
+    property string text: ''
+
+    /// If set to true, the toast duration will be long
+    property bool longDuration: false
+
+    readonly property string m_TOAST_MESSAGE: "quickandroid.Toast.showToast"
+
+    /// Displays the Toast with the current set text and duration
+    function show() {
+        SystemDispatcher.dispatch(m_TOAST_MESSAGE, {
+                                      text: text,
+                                      longLength: longDuration
+                                  });
+    }
+
+    Component.onCompleted: {
+        SystemDispatcher.loadClass("quickandroid.Toast");
+    }
+}
+

--- a/QuickAndroid/qmldir
+++ b/QuickAndroid/qmldir
@@ -38,3 +38,4 @@ ImagePicker 0.1 ImagePicker.qml
 Page 0.1 Page.qml
 PageStack 0.1 PageStack.qml
 Ink 0.1 Ink.qml
+Toast 0.1 Toast.qml

--- a/QuickAndroid/quickandroid.qrc
+++ b/QuickAndroid/quickandroid.qrc
@@ -102,5 +102,6 @@
         <file>Ink.qml</file>
         <file>Private/RippleSurface.qml</file>
         <file>Private/incubator.js</file>
+        <file>Toast.qml</file>
     </qresource>
 </RCC>

--- a/java/quickandroid/Toast.java
+++ b/java/quickandroid/Toast.java
@@ -1,0 +1,40 @@
+package quickandroid;
+
+import android.app.Activity;
+import java.util.Map;
+
+import org.qtproject.qt5.android.QtNative;
+
+public class Toast {
+    public static final String TOAST_MESSAGE = "quickandroid.Toast.showToast";
+
+    private static final String TAG = "quickandroid.Toast";
+
+    static {
+        SystemDispatcher.addListener(new SystemDispatcher.Listener() {
+            public void onDispatched(String type, Map message) {
+                if (type.equals(TOAST_MESSAGE)) {
+                    showToast(message);
+                }
+            }
+        });
+    }
+
+    static void showToast(Map message) {
+        if (!message.containsKey("text")) {
+            Log.d(TAG, "showToast: no text");
+            return;
+        }
+
+        int duration = android.widget.Toast.LENGTH_SHORT;
+        if (message.containsKey("longLength")) {
+            Boolean isLong = (Boolean)message.get("longLength");
+            if (isLong != null && isLong == true)
+                duration = android.widget.Toast.LENGTH_LONG;
+        }
+
+        Activity activity = QtNative.activity();
+        activity.runOnUiThread(new ToastRunnable(activity, (String)message.get("text"), duration));
+    }
+}
+

--- a/java/quickandroid/ToastRunnable.java
+++ b/java/quickandroid/ToastRunnable.java
@@ -1,0 +1,22 @@
+package quickandroid;
+
+import android.app.Activity;
+import android.widget.Toast;
+
+public class ToastRunnable implements Runnable {
+    private Activity activity;
+    private String text;
+    private int duration;
+
+    public ToastRunnable(Activity activity, String text, int duration) {
+        this.activity = activity;
+        this.text = text;
+        this.duration = duration;
+    }
+
+    @Override
+    public void run() {
+        Toast.makeText(activity, text, duration).show();
+    }
+}
+


### PR DESCRIPTION
Hello.

I just stumbled upon this project. Thanks for this code, it helped me a lot.

Tho I found that it was missing the support for [Toast](https://developer.android.com/reference/android/widget/Toast.html)s, which would be pretty easy to implement.

So this is my little contribution to this project.

Sorry, I did not create any examples, but it should be pretty straightforward: instantiate the Toast, set its text, (optionally) set its length to long and call show().
